### PR TITLE
Integrate HW-MGMT 7.0040.4001 Changes

### DIFF
--- a/patch/0030-1-platform-mellanox-nvsw-sn2201-Add-check-for-platform.patch
+++ b/patch/0030-1-platform-mellanox-nvsw-sn2201-Add-check-for-platform.patch
@@ -1,0 +1,47 @@
+From d065f198bf6eb0431c124589efbcbf2b54ae0303 Mon Sep 17 00:00:00 2001
+From: Chen Ni <nichen@iscas.ac.cn>
+Date: Wed, 5 Jun 2024 11:27:45 +0800
+Subject: [PATCH] platform/mellanox: nvsw-sn2201: Add check for
+ platform_device_add_resources
+
+[ Upstream commit d56fbfbaf592a115b2e11c1044829afba34069d2 ]
+
+Add check for the return value of platform_device_add_resources() and
+return the error if it fails in order to catch the error.
+
+Signed-off-by: Chen Ni <nichen@iscas.ac.cn>
+Link: https://lore.kernel.org/r/20240605032745.2916183-1-nichen@iscas.ac.cn
+Reviewed-by: Hans de Goede <hdegoede@redhat.com>
+Signed-off-by: Hans de Goede <hdegoede@redhat.com>
+Signed-off-by: Sasha Levin <sashal@kernel.org>
+---
+ drivers/platform/mellanox/nvsw-sn2201.c | 5 ++++-
+ 1 file changed, 4 insertions(+), 1 deletion(-)
+
+diff --git a/drivers/platform/mellanox/nvsw-sn2201.c b/drivers/platform/mellanox/nvsw-sn2201.c
+index 7b9c107..f53baf7 100644
+--- a/drivers/platform/mellanox/nvsw-sn2201.c
++++ b/drivers/platform/mellanox/nvsw-sn2201.c
+@@ -1194,6 +1194,7 @@ static int nvsw_sn2201_config_pre_init(struct nvsw_sn2201 *nvsw_sn2201)
+ static int nvsw_sn2201_probe(struct platform_device *pdev)
+ {
+ 	struct nvsw_sn2201 *nvsw_sn2201;
++	int ret;
+ 
+ 	nvsw_sn2201 = devm_kzalloc(&pdev->dev, sizeof(*nvsw_sn2201), GFP_KERNEL);
+ 	if (!nvsw_sn2201)
+@@ -1201,8 +1202,10 @@ static int nvsw_sn2201_probe(struct platform_device *pdev)
+ 
+ 	nvsw_sn2201->dev = &pdev->dev;
+ 	platform_set_drvdata(pdev, nvsw_sn2201);
+-	platform_device_add_resources(pdev, nvsw_sn2201_lpc_io_resources,
++	ret = platform_device_add_resources(pdev, nvsw_sn2201_lpc_io_resources,
+ 				      ARRAY_SIZE(nvsw_sn2201_lpc_io_resources));
++	if (ret)
++		return ret;
+ 
+ 	nvsw_sn2201->main_mux_deferred_nr = NVSW_SN2201_MAIN_MUX_DEFER_NR;
+ 	nvsw_sn2201->main_mux_devs = nvsw_sn2201_main_mux_brdinfo;
+-- 
+2.8.4
+

--- a/patch/0030-platform-mellanox-nvsw-sn2201-change-fans-i2c-busses.patch
+++ b/patch/0030-platform-mellanox-nvsw-sn2201-change-fans-i2c-busses.patch
@@ -1,8 +1,7 @@
-From ddec9cfeb44ed194cadee824f3f49c057bf7a560 Mon Sep 17 00:00:00 2001
+From ac10df67c019b8ee1c80b46390759669cd69862f Mon Sep 17 00:00:00 2001
 From: Michael Shych <michaelsh@nvidia.com>
 Date: Wed, 12 Jul 2023 14:26:38 +0000
-Subject: [PATH backport v6.1 30/32] platform: mellanox: nvsw-sn2201: change
- fans i2c busses.
+Subject: [PATCH 2/4] platform: mellanox: nvsw-sn2201: change fans i2c busses.
 
 Link: https://www.spinics.net/lists/platform-driver-x86/msg39647.html
 
@@ -18,7 +17,7 @@ Signed-off-by: Vadim Pasternak <vadimp@nvidia.com>
  1 file changed, 8 insertions(+), 4 deletions(-)
 
 diff --git a/drivers/platform/mellanox/nvsw-sn2201.c b/drivers/platform/mellanox/nvsw-sn2201.c
-index 7b9c107c17ce..75b699676ca6 100644
+index f53baf7e7..1a7c45aa4 100644
 --- a/drivers/platform/mellanox/nvsw-sn2201.c
 +++ b/drivers/platform/mellanox/nvsw-sn2201.c
 @@ -84,6 +84,10 @@

--- a/patch/0087-platform-mellanox-indicate-deferred-I2C-bus-creation.patch
+++ b/patch/0087-platform-mellanox-indicate-deferred-I2C-bus-creation.patch
@@ -1,7 +1,7 @@
-From ab5040e2b99cc3eb57eaa266b90877bcc38c28ed Mon Sep 17 00:00:00 2001
+From 1c43cf584d3fd62823dd3b28018481f15a8836c7 Mon Sep 17 00:00:00 2001
 From: Michael Shych <michaelsh@nvidia.com>
 Date: Wed, 29 Nov 2023 13:12:38 +0000
-Subject: [PATCH v1 1/1] platform: mellanox: indicate deferred I2C bus creation
+Subject: [PATCH 3/4] platform: mellanox: indicate deferred I2C bus creation
  for a hot-plug driver
 
 It fixes timing issue when during initialization hot-plug driver
@@ -15,7 +15,7 @@ Signed-off-by: Michael Shych <michaelsh@nvidia.com>
  1 file changed, 1 insertion(+)
 
 diff --git a/drivers/platform/mellanox/nvsw-sn2201.c b/drivers/platform/mellanox/nvsw-sn2201.c
-index 65b677690..79e4d0619 100644
+index 1a7c45aa4..a3e2bc6d6 100644
 --- a/drivers/platform/mellanox/nvsw-sn2201.c
 +++ b/drivers/platform/mellanox/nvsw-sn2201.c
 @@ -520,6 +520,7 @@ struct mlxreg_core_hotplug_platform_data nvsw_sn2201_hotplug = {
@@ -27,5 +27,5 @@ index 65b677690..79e4d0619 100644
  
  /* SN2201 static devices. */
 -- 
-2.14.1
+2.20.1
 

--- a/patch/0091-platform-mellanox-mlxreg-dpu-Add-initial-support-for.patch
+++ b/patch/0091-platform-mellanox-mlxreg-dpu-Add-initial-support-for.patch
@@ -69,18 +69,19 @@ index ba56485cbe8c..e86723b44c2e 100644
  obj-$(CONFIG_MLXREG_LC) += mlxreg-lc.o
 diff --git a/drivers/platform/mellanox/mlxreg-dpu.c b/drivers/platform/mellanox/mlxreg-dpu.c
 new file mode 100644
-index 000000000000..f831d6dd5ece
+index 000000000..c6cfbee55
 --- /dev/null
 +++ b/drivers/platform/mellanox/mlxreg-dpu.c
-@@ -0,0 +1,625 @@
+@@ -0,0 +1,626 @@
 +// SPDX-License-Identifier: GPL-2.0+
 +/*
 + * Nvidia Data Processor Unit platform driver
 + *
-+ * Copyright (C) 2024 Nvidia Technologies Ltd.
++ * Copyright (C) 2025 Nvidia Technologies Ltd.
 + */
 +
 +#include <linux/device.h>
++#include <linux/dev_printk.h>
 +#include <linux/i2c.h>
 +#include <linux/module.h>
 +#include <linux/platform_data/mlxcpld.h>
@@ -389,13 +390,14 @@ index 000000000000..f831d6dd5ece
 +	.mask = MLXREG_DPU_AGGR_MASK,
 +};
 +
-+/* mlxreg_dpu - device private data
-+ * @dev: platform device;
-+ * @data: pltaform core data;
-+ * @io_data: register access platform data;
-+ * @io_regs: register access device;
-+ * @hotplug_data: hotplug platform data;
-+ * @hotplug: hotplug device;
++/**
++ * struct mlxreg_dpu - device private data
++ * @dev: platform device
++ * @data: platform core data
++ * @io_data: register access platform data
++ * @io_regs: register access device
++ * @hotplug_data: hotplug platform data
++ * @hotplug: hotplug device
 + */
 +struct mlxreg_dpu {
 +	struct device *dev;
@@ -478,6 +480,11 @@ index 000000000000..f831d6dd5ece
 +	return false;
 +}
 +
++static const struct reg_default mlxreg_dpu_regmap_default[] = {
++        { MLXREG_DPU_REG_PG_EVENT_OFFSET, 0x00 },
++        { MLXREG_DPU_REG_HEALTH_EVENT_OFFSET, 0x00 },
++};
++
 +/* Configuration for the register map of a device with 2 bytes address space. */
 +static const struct regmap_config mlxreg_dpu_regmap_conf = {
 +	.reg_bits = 16,
@@ -487,10 +494,13 @@ index 000000000000..f831d6dd5ece
 +	.writeable_reg = mlxreg_dpu_writeable_reg,
 +	.readable_reg = mlxreg_dpu_readable_reg,
 +	.volatile_reg = mlxreg_dpu_volatile_reg,
++	.reg_defaults = mlxreg_dpu_regmap_default,
++	.num_reg_defaults = ARRAY_SIZE(mlxreg_dpu_regmap_default),
 +};
 +
-+static int mlxreg_dpu_copy_hotplug_data(struct device *dev, struct mlxreg_dpu *mlxreg_dpu,
-+					struct mlxreg_core_hotplug_platform_data *hotplug_data)
++static int
++mlxreg_dpu_copy_hotplug_data(struct device *dev, struct mlxreg_dpu *mlxreg_dpu,
++			     const struct mlxreg_core_hotplug_platform_data *hotplug_data)
 +{
 +	struct mlxreg_core_item *item;
 +	int i;
@@ -502,18 +512,15 @@ index 000000000000..f831d6dd5ece
 +
 +	mlxreg_dpu->hotplug_data->items = devm_kmemdup(dev, hotplug_data->items,
 +						       mlxreg_dpu->hotplug_data->counter *
-+						       sizeof(*hotplug_data->items),
++						       sizeof(*mlxreg_dpu->hotplug_data->items),
 +						       GFP_KERNEL);
 +	if (!mlxreg_dpu->hotplug_data->items)
 +		return -ENOMEM;
 +
 +	item = mlxreg_dpu->hotplug_data->items;
-+	for (i = 0; i < mlxreg_dpu->hotplug_data->counter; i++, item++) {
-+		item = devm_kmemdup(dev, &hotplug_data->items[i], sizeof(*item), GFP_KERNEL);
-+		if (!item)
-+			return -ENOMEM;
++	for (i = 0; i < hotplug_data->counter; i++, item++) {
 +		item->data = devm_kmemdup(dev, hotplug_data->items[i].data,
-+					  hotplug_data->items[i].count * sizeof(item->data),
++					  hotplug_data->items[i].count * sizeof(*item->data),
 +					  GFP_KERNEL);
 +		if (!item->data)
 +			return -ENOMEM;
@@ -533,6 +540,7 @@ index 000000000000..f831d6dd5ece
 +	err = regmap_read(regmap, MLXREG_DPU_REG_CONFIG3_OFFSET, &regval);
 +	if (err)
 +		return err;
++
 +	switch (regval) {
 +	case MLXREG_DPU_BF3:
 +		/* Copy platform specific hotplug data. */
@@ -552,15 +560,15 @@ index 000000000000..f831d6dd5ece
 +	if (mlxreg_dpu->io_data) {
 +		mlxreg_dpu->io_data->regmap = regmap;
 +		mlxreg_dpu->io_regs =
-+		platform_device_register_resndata(dev, "mlxreg-io", data->slot, NULL, 0,
-+						  mlxreg_dpu->io_data,
-+						  sizeof(*mlxreg_dpu->io_data));
++			platform_device_register_resndata(dev, "mlxreg-io",
++							  data->slot, NULL, 0,
++							  mlxreg_dpu->io_data,
++							  sizeof(*mlxreg_dpu->io_data));
 +		if (IS_ERR(mlxreg_dpu->io_regs)) {
 +			dev_err(dev, "Failed to create regio for client %s at bus %d at addr 0x%02x\n",
 +				data->hpdev.brdinfo->type, data->hpdev.nr,
 +				data->hpdev.brdinfo->addr);
-+			err = PTR_ERR(mlxreg_dpu->io_regs);
-+			goto fail_register_io;
++			return PTR_ERR(mlxreg_dpu->io_regs);
 +		}
 +	}
 +
@@ -569,9 +577,10 @@ index 000000000000..f831d6dd5ece
 +		mlxreg_dpu->hotplug_data->regmap = regmap;
 +		mlxreg_dpu->hotplug_data->irq = irq;
 +		mlxreg_dpu->hotplug =
-+		platform_device_register_resndata(dev, "mlxreg-hotplug", data->slot, NULL, 0,
-+						  mlxreg_dpu->hotplug_data,
-+						  sizeof(*mlxreg_dpu->hotplug_data));
++			platform_device_register_resndata(dev, "mlxreg-hotplug",
++							  data->slot, NULL, 0,
++							  mlxreg_dpu->hotplug_data,
++							  sizeof(*mlxreg_dpu->hotplug_data));
 +		if (IS_ERR(mlxreg_dpu->hotplug)) {
 +			err = PTR_ERR(mlxreg_dpu->hotplug);
 +			goto fail_register_hotplug;
@@ -582,16 +591,13 @@ index 000000000000..f831d6dd5ece
 +
 +fail_register_hotplug:
 +	platform_device_unregister(mlxreg_dpu->io_regs);
-+fail_register_io:
 +
 +	return err;
 +}
 +
 +static void mlxreg_dpu_config_exit(struct mlxreg_dpu *mlxreg_dpu)
 +{
-+	/* Unregister hotplug driver. */
 +	platform_device_unregister(mlxreg_dpu->hotplug);
-+	/* Unregister IO access driver. */
 +	platform_device_unregister(mlxreg_dpu->io_regs);
 +}
 +
@@ -606,13 +612,13 @@ index 000000000000..f831d6dd5ece
 +	if (!data || !data->hpdev.brdinfo)
 +		return -EINVAL;
 +
-+	mlxreg_dpu = devm_kzalloc(&pdev->dev, sizeof(*mlxreg_dpu), GFP_KERNEL);
-+	if (!mlxreg_dpu)
-+		return -ENOMEM;
-+
 +	data->hpdev.adapter = i2c_get_adapter(data->hpdev.nr);
 +	if (!data->hpdev.adapter)
 +		return -EPROBE_DEFER;
++
++	mlxreg_dpu = devm_kzalloc(&pdev->dev, sizeof(*mlxreg_dpu), GFP_KERNEL);
++	if (!mlxreg_dpu)
++		return -ENOMEM;
 +
 +	/* Create device at the top of DPU I2C tree.*/
 +	data->hpdev.client = i2c_new_client_device(data->hpdev.adapter,
@@ -624,8 +630,7 @@ index 000000000000..f831d6dd5ece
 +		goto i2c_new_device_fail;
 +	}
 +
-+	regmap = devm_regmap_init_i2c(data->hpdev.client,
-+				      &mlxreg_dpu_regmap_conf);
++	regmap = devm_regmap_init_i2c(data->hpdev.client, &mlxreg_dpu_regmap_conf);
 +	if (IS_ERR(regmap)) {
 +		dev_err(&pdev->dev, "Failed to create regmap for client %s at bus %d at addr 0x%02x\n",
 +			data->hpdev.brdinfo->type, data->hpdev.nr, data->hpdev.brdinfo->addr);
@@ -647,12 +652,9 @@ index 000000000000..f831d6dd5ece
 +	mlxreg_dpu->dev = &pdev->dev;
 +	platform_set_drvdata(pdev, mlxreg_dpu);
 +
-+	/* Configure DPU. */
 +	err = mlxreg_dpu_config_init(mlxreg_dpu, regmap, data, data->hpdev.brdinfo->irq);
 +	if (err)
 +		goto mlxreg_dpu_config_init_fail;
-+
-+	return err;
 +
 +mlxreg_dpu_config_init_fail:
 +regcache_sync_fail:
@@ -697,7 +699,6 @@ index 000000000000..f831d6dd5ece
 +MODULE_DESCRIPTION("Nvidia Data Processor Unit platform driver");
 +MODULE_LICENSE("Dual BSD/GPL");
 +MODULE_ALIAS("platform:mlxreg-dpu");
-+
 -- 
-2.34.1
+2.44.0
 

--- a/patch/0095-platform-mellanox-nvsw-sn2201-Add-support-for-new-sy.patch
+++ b/patch/0095-platform-mellanox-nvsw-sn2201-Add-support-for-new-sy.patch
@@ -1,8 +1,8 @@
-From 693ea1c72c6f1b83232c043fdb1b175a450bc172 Mon Sep 17 00:00:00 2001
-From: Vadim Pasternak <vadimp@nvidia.com>
-Date: Wed, 7 Aug 2024 00:09:11 +0000
-Subject: [PATCH backport 6.1 1/1] platform: mellanox: nvsw-sn2200: Add support
- for new system flavour
+From 13e4e0e5b566a116e2107a0a959d2b294b388b42 Mon Sep 17 00:00:00 2001
+From: Oleksandr Shamray <oleksandrs@nvidia.com>
+Date: Wed, 11 Dec 2024 17:49:45 +0200
+Subject: [PATCH 4/4] platform: mellanox: nvsw-sn2200: Add support for new
+ system flavour
 
 Add support for SN2201 system flavour, which is fitting OCP rack
 form-factor and feeded from external power source through the rack
@@ -15,11 +15,11 @@ For new system flavour:
 
 Signed-off-by: Vadim Pasternak <vadimp@nvidia.com>
 ---
- drivers/platform/mellanox/nvsw-sn2201.c | 111 +++++++++++++++++++++++-
- 1 file changed, 108 insertions(+), 3 deletions(-)
+ drivers/platform/mellanox/nvsw-sn2201.c | 112 +++++++++++++++++++++++-
+ 1 file changed, 109 insertions(+), 3 deletions(-)
 
 diff --git a/drivers/platform/mellanox/nvsw-sn2201.c b/drivers/platform/mellanox/nvsw-sn2201.c
-index 2612bb5f82a3..d604069e3313 100644
+index a3e2bc6d6..64c705f3b 100644
 --- a/drivers/platform/mellanox/nvsw-sn2201.c
 +++ b/drivers/platform/mellanox/nvsw-sn2201.c
 @@ -6,6 +6,7 @@
@@ -103,7 +103,7 @@ index 2612bb5f82a3..d604069e3313 100644
  };
  
  /* SN2201 default static board info. */
-@@ -608,6 +647,58 @@ static struct mlxreg_hotplug_device nvsw_sn2201_static_brdinfo[] = {
+@@ -608,6 +647,59 @@ static struct mlxreg_hotplug_device nvsw_sn2201_static_brdinfo[] = {
  	},
  };
  
@@ -159,10 +159,11 @@ index 2612bb5f82a3..d604069e3313 100644
 +	},
 +};
 +
++
  /* LED default data. */
  static struct mlxreg_core_data nvsw_sn2201_led_data[] = {
  	{
-@@ -982,7 +1073,10 @@ static int nvsw_sn2201_config_init(struct nvsw_sn2201 *nvsw_sn2201, void *regmap
+@@ -982,7 +1074,10 @@ static int nvsw_sn2201_config_init(struct nvsw_sn2201 *nvsw_sn2201, void *regmap
  	nvsw_sn2201->io_data = &nvsw_sn2201_regs_io;
  	nvsw_sn2201->led_data = &nvsw_sn2201_led;
  	nvsw_sn2201->wd_data = &nvsw_sn2201_wd;
@@ -174,11 +175,12 @@ index 2612bb5f82a3..d604069e3313 100644
  
  	/* Register IO access driver. */
  	if (nvsw_sn2201->io_data) {
-@@ -1199,11 +1293,17 @@ static int nvsw_sn2201_config_pre_init(struct nvsw_sn2201 *nvsw_sn2201)
+@@ -1199,12 +1294,18 @@ static int nvsw_sn2201_config_pre_init(struct nvsw_sn2201 *nvsw_sn2201)
  static int nvsw_sn2201_probe(struct platform_device *pdev)
  {
  	struct nvsw_sn2201 *nvsw_sn2201;
 +	const char *sku;
+ 	int ret;
  
  	nvsw_sn2201 = devm_kzalloc(&pdev->dev, sizeof(*nvsw_sn2201), GFP_KERNEL);
  	if (!nvsw_sn2201)
@@ -191,8 +193,8 @@ index 2612bb5f82a3..d604069e3313 100644
 +
  	nvsw_sn2201->dev = &pdev->dev;
  	platform_set_drvdata(pdev, nvsw_sn2201);
- 	platform_device_add_resources(pdev, nvsw_sn2201_lpc_io_resources,
-@@ -1212,8 +1312,13 @@ static int nvsw_sn2201_probe(struct platform_device *pdev)
+ 	ret = platform_device_add_resources(pdev, nvsw_sn2201_lpc_io_resources,
+@@ -1215,8 +1316,13 @@ static int nvsw_sn2201_probe(struct platform_device *pdev)
  	nvsw_sn2201->main_mux_deferred_nr = NVSW_SN2201_MAIN_MUX_DEFER_NR;
  	nvsw_sn2201->main_mux_devs = nvsw_sn2201_main_mux_brdinfo;
  	nvsw_sn2201->cpld_devs = nvsw_sn2201_cpld_brdinfo;
@@ -209,5 +211,5 @@ index 2612bb5f82a3..d604069e3313 100644
  	return nvsw_sn2201_config_pre_init(nvsw_sn2201);
  }
 -- 
-2.44.0
+2.20.1
 

--- a/patch/0098-platform-mellanox-Downstream-Add-support-for-new-Nvi.patch
+++ b/patch/0098-platform-mellanox-Downstream-Add-support-for-new-Nvi.patch
@@ -1,0 +1,530 @@
+From 509f23639fc2c60df25171533f8166cf169d7d3d Mon Sep 17 00:00:00 2001
+From: Oleksandr Shamray <oleksandrs@nvidia.com>
+Date: Mon, 9 Dec 2024 11:42:37 +0200
+Subject: [PATCH 07/15] platform: mellanox: Downstream: Add support for new
+ Nvidia IB DGX system based on class VMOD0010
+
+This system is based on Nvidia QM9700 64x400G QTM-2 IB switch, with the
+following key changes:
+
+Key changes:
+  1.Power Supply: Rack busbar input power ORv3 DC 48V-54V
+  2.Dimensions MGX/DGX 1U compliance
+
+Signed-off-by: Oleksandr Shamray <oleksandrs@nvidia.com>
+---
+ drivers/platform/mellanox/mlx-platform.c | 456 +++++++++++++++++++++++++++++++
+ 1 file changed, 456 insertions(+)
+
+diff --git a/drivers/platform/mellanox/mlx-platform.c b/drivers/platform/mellanox/mlx-platform.c
+index 5796e46..9346c76 100644
+--- a/drivers/platform/mellanox/mlx-platform.c
++++ b/drivers/platform/mellanox/mlx-platform.c
+@@ -822,6 +822,16 @@ static struct mlxreg_core_data mlxplat_mlxcpld_default_psu_items_data[] = {
+ 	},
+ };
+ 
++/* Platform hotplug dgx data */
++static struct mlxreg_core_data mlxplat_mlxcpld_dgx_psu_items_data[] = {
++	{
++		.label = "pdb1",
++		.reg = MLXPLAT_CPLD_LPC_REG_PSU_OFFSET,
++		.mask = BIT(0),
++		.hpdev.nr = MLXPLAT_CPLD_NR_NONE,
++	},
++};
++
+ static struct mlxreg_core_data mlxplat_mlxcpld_default_pwr_items_data[] = {
+ 	{
+ 		.label = "pwr1",
+@@ -871,6 +881,15 @@ static struct mlxreg_core_data mlxplat_mlxcpld_default_pwr_ng800_items_data[] =
+ 	},
+ };
+ 
++static struct mlxreg_core_data mlxplat_mlxcpld_dgx_pwr_items_data[] = {
++	{
++		.label = "pwr1",
++		.reg = MLXPLAT_CPLD_LPC_REG_PWR_OFFSET,
++		.mask = BIT(0),
++		.hpdev.nr = MLXPLAT_CPLD_NR_NONE ,
++	},
++};
++
+ static struct mlxreg_core_data mlxplat_mlxcpld_default_fan_items_data[] = {
+ 	{
+ 		.label = "fan1",
+@@ -1594,6 +1613,45 @@ static struct mlxreg_core_item mlxplat_mlxcpld_ext_items[] = {
+ 	}
+ };
+ 
++static struct mlxreg_core_item mlxplat_mlxcpld_ext_dgx_items[] = {
++	{
++		.data = mlxplat_mlxcpld_dgx_psu_items_data,
++		.aggr_mask = MLXPLAT_CPLD_AGGR_PSU_MASK_DEF,
++		.reg = MLXPLAT_CPLD_LPC_REG_PSU_OFFSET,
++		.mask = MLXPLAT_CPLD_PSU_MASK,
++		.count = ARRAY_SIZE(mlxplat_mlxcpld_dgx_psu_items_data),
++		.inversed = 1,
++		.health = false,
++	},
++	{
++		.data = mlxplat_mlxcpld_dgx_pwr_items_data,
++		.aggr_mask = MLXPLAT_CPLD_AGGR_PWR_MASK_DEF,
++		.reg = MLXPLAT_CPLD_LPC_REG_PWR_OFFSET,
++		.mask = MLXPLAT_CPLD_PWR_MASK,
++		.count = ARRAY_SIZE(mlxplat_mlxcpld_dgx_pwr_items_data),
++		.inversed = 0,
++		.health = false,
++	},
++	{
++		.data = mlxplat_mlxcpld_default_ng_fan_items_data,
++		.aggr_mask = MLXPLAT_CPLD_AGGR_MASK_NG_DEF,
++		.reg = MLXPLAT_CPLD_LPC_REG_FAN_OFFSET,
++		.mask = MLXPLAT_CPLD_FAN_NG_MASK,
++		.count = ARRAY_SIZE(mlxplat_mlxcpld_default_ng_fan_items_data),
++		.inversed = 1,
++		.health = false,
++	},
++	{
++		.data = mlxplat_mlxcpld_default_asic_items_data,
++		.aggr_mask = MLXPLAT_CPLD_AGGR_MASK_NG_DEF,
++		.reg = MLXPLAT_CPLD_LPC_REG_ASIC_HEALTH_OFFSET,
++		.mask = MLXPLAT_CPLD_ASIC_MASK,
++		.count = ARRAY_SIZE(mlxplat_mlxcpld_default_asic_items_data),
++		.inversed = 0,
++		.health = true,
++	},
++};
++
+ static struct mlxreg_core_item mlxplat_mlxcpld_ng800_items[] = {
+ 	{
+ 		.data = mlxplat_mlxcpld_default_ng_psu_items_data,
+@@ -2081,6 +2139,16 @@ struct mlxreg_core_hotplug_platform_data mlxplat_mlxcpld_ext_data = {
+ };
+ 
+ static
++struct mlxreg_core_hotplug_platform_data mlxplat_mlxcpld_dgx_ext_data = {
++	.items = mlxplat_mlxcpld_ext_dgx_items,
++	.counter = ARRAY_SIZE(mlxplat_mlxcpld_ext_dgx_items),
++	.cell = MLXPLAT_CPLD_LPC_REG_AGGR_OFFSET,
++	.mask = MLXPLAT_CPLD_AGGR_MASK_NG_DEF | MLXPLAT_CPLD_AGGR_MASK_COMEX,
++	.cell_low = MLXPLAT_CPLD_LPC_REG_AGGRLO_OFFSET,
++	.mask_low = MLXPLAT_CPLD_LOW_AGGR_MASK_LOW | MLXPLAT_CPLD_LOW_AGGR_MASK_ASIC2,
++};
++
++static
+ struct mlxreg_core_hotplug_platform_data mlxplat_mlxcpld_ng800_data = {
+ 	.items = mlxplat_mlxcpld_ng800_items,
+ 	.counter = ARRAY_SIZE(mlxplat_mlxcpld_ng800_items),
+@@ -5256,6 +5324,361 @@ static struct mlxreg_core_platform_data mlxplat_default_ng_regs_io_data = {
+ 		.counter = ARRAY_SIZE(mlxplat_mlxcpld_default_ng_regs_io_data),
+ };
+ 
++
++
++/* Platform register access for next generation systems families data */
++static struct mlxreg_core_data mlxplat_mlxcpld_dgx_ng_regs_io_data[] = {
++	{
++		.label = "cpld1_version",
++		.reg = MLXPLAT_CPLD_LPC_REG_CPLD1_VER_OFFSET,
++		.bit = GENMASK(7, 0),
++		.mode = 0444,
++	},
++	{
++		.label = "cpld2_version",
++		.reg = MLXPLAT_CPLD_LPC_REG_CPLD2_VER_OFFSET,
++		.bit = GENMASK(7, 0),
++		.mode = 0444,
++	},
++	{
++		.label = "cpld3_version",
++		.reg = MLXPLAT_CPLD_LPC_REG_CPLD3_VER_OFFSET,
++		.bit = GENMASK(7, 0),
++		.mode = 0444,
++	},
++	{
++		.label = "cpld4_version",
++		.reg = MLXPLAT_CPLD_LPC_REG_CPLD4_VER_OFFSET,
++		.bit = GENMASK(7, 0),
++		.mode = 0444,
++	},
++	{
++		.label = "cpld1_pn",
++		.reg = MLXPLAT_CPLD_LPC_REG_CPLD1_PN_OFFSET,
++		.bit = GENMASK(15, 0),
++		.mode = 0444,
++		.regnum = 2,
++	},
++	{
++		.label = "cpld2_pn",
++		.reg = MLXPLAT_CPLD_LPC_REG_CPLD2_PN_OFFSET,
++		.bit = GENMASK(15, 0),
++		.mode = 0444,
++		.regnum = 2,
++	},
++	{
++		.label = "cpld3_pn",
++		.reg = MLXPLAT_CPLD_LPC_REG_CPLD3_PN_OFFSET,
++		.bit = GENMASK(15, 0),
++		.mode = 0444,
++		.regnum = 2,
++	},
++	{
++		.label = "cpld4_pn",
++		.reg = MLXPLAT_CPLD_LPC_REG_CPLD4_PN_OFFSET,
++		.bit = GENMASK(15, 0),
++		.mode = 0444,
++		.regnum = 2,
++	},
++	{
++		.label = "cpld1_version_min",
++		.reg = MLXPLAT_CPLD_LPC_REG_CPLD1_MVER_OFFSET,
++		.bit = GENMASK(7, 0),
++		.mode = 0444,
++	},
++	{
++		.label = "cpld2_version_min",
++		.reg = MLXPLAT_CPLD_LPC_REG_CPLD2_MVER_OFFSET,
++		.bit = GENMASK(7, 0),
++		.mode = 0444,
++	},
++	{
++		.label = "cpld3_version_min",
++		.reg = MLXPLAT_CPLD_LPC_REG_CPLD3_MVER_OFFSET,
++		.bit = GENMASK(7, 0),
++		.mode = 0444,
++	},
++	{
++		.label = "cpld4_version_min",
++		.reg = MLXPLAT_CPLD_LPC_REG_CPLD4_MVER_OFFSET,
++		.bit = GENMASK(7, 0),
++		.mode = 0444,
++	},
++	{
++		.label = "asic_reset",
++		.reg = MLXPLAT_CPLD_LPC_REG_RESET_GP2_OFFSET,
++		.mask = GENMASK(7, 0) & ~BIT(3),
++		.mode = 0200,
++	},
++	{
++		.label = "reset_long_pb",
++		.reg = MLXPLAT_CPLD_LPC_REG_RESET_CAUSE_OFFSET,
++		.mask = GENMASK(7, 0) & ~BIT(0),
++		.mode = 0444,
++	},
++	{
++		.label = "reset_short_pb",
++		.reg = MLXPLAT_CPLD_LPC_REG_RESET_CAUSE_OFFSET,
++		.mask = GENMASK(7, 0) & ~BIT(1),
++		.mode = 0444,
++	},
++	{
++		.label = "reset_aux_pwr_or_ref",
++		.reg = MLXPLAT_CPLD_LPC_REG_RESET_CAUSE_OFFSET,
++		.mask = GENMASK(7, 0) & ~BIT(2),
++		.mode = 0444,
++	},
++	{
++		.label = "reset_swb_dc_dc_pwr_fail",
++		.reg = MLXPLAT_CPLD_LPC_REG_RESET_CAUSE_OFFSET,
++		.mask = GENMASK(7, 0) & ~BIT(3),
++		.mode = 0444,
++	},
++	{
++		.label = "reset_from_asic",
++		.reg = MLXPLAT_CPLD_LPC_REG_RESET_CAUSE_OFFSET,
++		.mask = GENMASK(7, 0) & ~BIT(5),
++		.mode = 0444,
++	},
++	{
++		.label = "reset_swb_wd",
++		.reg = MLXPLAT_CPLD_LPC_REG_RESET_CAUSE_OFFSET,
++		.mask = GENMASK(7, 0) & ~BIT(6),
++		.mode = 0444,
++	},
++	{
++		.label = "reset_asic_thermal",
++		.reg = MLXPLAT_CPLD_LPC_REG_RESET_CAUSE_OFFSET,
++		.mask = GENMASK(7, 0) & ~BIT(7),
++		.mode = 0444,
++	},
++	{
++		.label = "reset_sw_reset",
++		.reg = MLXPLAT_CPLD_LPC_REG_RST_CAUSE1_OFFSET,
++		.mask = GENMASK(7, 0) & ~BIT(0),
++		.mode = 0444,
++	},
++	{
++		.label = "reset_comex_pwr_fail",
++		.reg = MLXPLAT_CPLD_LPC_REG_RST_CAUSE1_OFFSET,
++		.mask = GENMASK(7, 0) & ~BIT(3),
++		.mode = 0444,
++	},
++	{
++		.label = "reset_platform",
++		.reg = MLXPLAT_CPLD_LPC_REG_RST_CAUSE1_OFFSET,
++		.mask = GENMASK(7, 0) & ~BIT(4),
++		.mode = 0444,
++	},
++	{
++		.label = "reset_soc",
++		.reg = MLXPLAT_CPLD_LPC_REG_RST_CAUSE1_OFFSET,
++		.mask = GENMASK(7, 0) & ~BIT(5),
++		.mode = 0444,
++	},
++	{
++		.label = "reset_comex_wd",
++		.reg = MLXPLAT_CPLD_LPC_REG_RST_CAUSE1_OFFSET,
++		.mask = GENMASK(7, 0) & ~BIT(6),
++		.mode = 0444,
++	},
++	{
++		.label = "reset_system",
++		.reg = MLXPLAT_CPLD_LPC_REG_RST_CAUSE2_OFFSET,
++		.mask = GENMASK(7, 0) & ~BIT(1),
++		.mode = 0444,
++	},
++	{
++		.label = "reset_sw_pwr_off",
++		.reg = MLXPLAT_CPLD_LPC_REG_RST_CAUSE2_OFFSET,
++		.mask = GENMASK(7, 0) & ~BIT(2),
++		.mode = 0444,
++	},
++	{
++		.label = "reset_comex_thermal",
++		.reg = MLXPLAT_CPLD_LPC_REG_RST_CAUSE2_OFFSET,
++		.mask = GENMASK(7, 0) & ~BIT(3),
++		.mode = 0444,
++	},
++	{
++		.label = "reset_reload_bios",
++		.reg = MLXPLAT_CPLD_LPC_REG_RST_CAUSE2_OFFSET,
++		.mask = GENMASK(7, 0) & ~BIT(5),
++		.mode = 0444,
++	},
++	{
++		.label = "reset_pdb_pwr_fail",
++		.reg = MLXPLAT_CPLD_LPC_REG_RST_CAUSE2_OFFSET,
++		.mask = GENMASK(7, 0) & ~BIT(6),
++		.mode = 0444,
++	},
++	{
++		.label = "pdb_reset_stby",
++		.reg = MLXPLAT_CPLD_LPC_REG_GP1_OFFSET,
++		.mask = GENMASK(7, 0) & ~BIT(0),
++		.mode = 0200,
++	},
++	{
++		.label = "pwr_cycle",
++		.reg = MLXPLAT_CPLD_LPC_REG_GP1_OFFSET,
++		.mask = GENMASK(7, 0) & ~BIT(2),
++		.mode = 0200,
++	},
++	{
++		.label = "pwr_down",
++		.reg = MLXPLAT_CPLD_LPC_REG_GP1_OFFSET,
++		.mask = GENMASK(7, 0) & ~BIT(3),
++		.mode = 0200,
++	},
++	{
++		.label = "deep_pwr_cycle",
++		.reg = MLXPLAT_CPLD_LPC_REG_GP1_OFFSET,
++		.mask = GENMASK(7, 0) & ~BIT(5),
++		.mode = 0200,
++	},
++	{
++		.label = "latch_reset",
++		.reg = MLXPLAT_CPLD_LPC_REG_GP1_OFFSET,
++		.mask = GENMASK(7, 0) & ~BIT(6),
++		.mode = 0200,
++	},
++	{
++		.label = "jtag_cap",
++		.reg = MLXPLAT_CPLD_LPC_REG_FU_CAP_OFFSET,
++		.mask = MLXPLAT_CPLD_FU_CAP_MASK,
++		.bit = 1,
++		.mode = 0444,
++	},
++	{
++		.label = "jtag_enable",
++		.reg = MLXPLAT_CPLD_LPC_REG_GP2_OFFSET,
++		.mask = GENMASK(7, 0) & ~BIT(4),
++		.mode = 0644,
++	},
++	{
++		.label = "dbg1",
++		.reg = MLXPLAT_CPLD_LPC_REG_DBG1_OFFSET,
++		.bit = GENMASK(7, 0),
++		.mode = 0644,
++	},
++	{
++		.label = "dbg2",
++		.reg = MLXPLAT_CPLD_LPC_REG_DBG2_OFFSET,
++		.bit = GENMASK(7, 0),
++		.mode = 0644,
++	},
++	{
++		.label = "dbg3",
++		.reg = MLXPLAT_CPLD_LPC_REG_DBG3_OFFSET,
++		.bit = GENMASK(7, 0),
++		.mode = 0644,
++	},
++	{
++		.label = "dbg4",
++		.reg = MLXPLAT_CPLD_LPC_REG_DBG4_OFFSET,
++		.bit = GENMASK(7, 0),
++		.mode = 0644,
++	},
++	{
++		.label = "asic_health",
++		.reg = MLXPLAT_CPLD_LPC_REG_ASIC_HEALTH_OFFSET,
++		.mask = MLXPLAT_CPLD_ASIC_MASK,
++		.bit = 1,
++		.mode = 0444,
++	},
++	{
++		.label = "fan_dir",
++		.reg = MLXPLAT_CPLD_LPC_REG_FAN_DIRECTION,
++		.bit = GENMASK(7, 0),
++		.mode = 0444,
++	},
++	{
++		.label = "bios_safe_mode",
++		.reg = MLXPLAT_CPLD_LPC_REG_GPCOM0_OFFSET,
++		.mask = GENMASK(7, 0) & ~BIT(4),
++		.mode = 0444,
++	},
++	{
++		.label = "bios_active_image",
++		.reg = MLXPLAT_CPLD_LPC_REG_GPCOM0_OFFSET,
++		.mask = GENMASK(7, 0) & ~BIT(5),
++		.mode = 0444,
++	},
++	{
++		.label = "bios_auth_fail",
++		.reg = MLXPLAT_CPLD_LPC_REG_GPCOM0_OFFSET,
++		.mask = GENMASK(7, 0) & ~BIT(6),
++		.mode = 0444,
++	},
++	{
++		.label = "bios_upgrade_fail",
++		.reg = MLXPLAT_CPLD_LPC_REG_GPCOM0_OFFSET,
++		.mask = GENMASK(7, 0) & ~BIT(7),
++		.mode = 0444,
++	},
++	{
++		.label = "voltreg_update_status",
++		.reg = MLXPLAT_CPLD_LPC_REG_GP0_RO_OFFSET,
++		.mask = MLXPLAT_CPLD_VOLTREG_UPD_MASK,
++		.bit = 5,
++		.mode = 0444,
++	},
++	{
++		.label = "pwr_converter_prog_en",
++		.reg = MLXPLAT_CPLD_LPC_REG_GP0_OFFSET,
++		.mask = GENMASK(7, 0) & ~BIT(0),
++		.mode = 0644,
++		.secured = 1,
++	},
++	{
++		.label = "vpd_wp",
++		.reg = MLXPLAT_CPLD_LPC_REG_GP0_OFFSET,
++		.mask = GENMASK(7, 0) & ~BIT(3),
++		.mode = 0644,
++	},
++	{
++		.label = "pcie_asic_reset_dis",
++		.reg = MLXPLAT_CPLD_LPC_REG_GP0_OFFSET,
++		.mask = GENMASK(7, 0) & ~BIT(4),
++		.mode = 0644,
++	},
++	{
++		.label = "shutdown_unlock",
++		.reg = MLXPLAT_CPLD_LPC_REG_GP0_OFFSET,
++		.mask = GENMASK(7, 0) & ~BIT(5),
++		.mode = 0644,
++	},
++	{
++		.label = "config1",
++		.reg = MLXPLAT_CPLD_LPC_REG_CONFIG1_OFFSET,
++		.bit = GENMASK(7, 0),
++		.mode = 0444,
++	},
++	{
++		.label = "config2",
++		.reg = MLXPLAT_CPLD_LPC_REG_CONFIG2_OFFSET,
++		.bit = GENMASK(7, 0),
++		.mode = 0444,
++	},
++	{
++		.label = "config3",
++		.reg = MLXPLAT_CPLD_LPC_REG_CONFIG3_OFFSET,
++		.bit = GENMASK(7, 0),
++		.mode = 0444,
++	},
++	{
++		.label = "ufm_version",
++		.reg = MLXPLAT_CPLD_LPC_REG_UFM_VERSION_OFFSET,
++		.bit = GENMASK(7, 0),
++		.mode = 0444,
++	},
++};
++
++static struct mlxreg_core_platform_data mlxplat_dgx_ng_regs_io_data = {
++		.data = mlxplat_mlxcpld_dgx_ng_regs_io_data,
++		.counter = ARRAY_SIZE(mlxplat_mlxcpld_dgx_ng_regs_io_data),
++};
++
+ /* Platform register access for modular systems families data */
+ static struct mlxreg_core_data mlxplat_mlxcpld_modular_regs_io_data[] = {
+ 	{
+@@ -8117,6 +8540,32 @@ static int __init mlxplat_dmi_ng400_matched(const struct dmi_system_id *dmi)
+ 	return mlxplat_register_platform_device();
+ }
+ 
++static int __init mlxplat_dmi_ng400_dgx_matched(const struct dmi_system_id *dmi)
++{
++	int i;
++
++	mlxplat_max_adap_num = MLXPLAT_CPLD_MAX_PHYS_ADAPTER_NUM;
++	mlxplat_mux_num = ARRAY_SIZE(mlxplat_default_mux_data);
++	mlxplat_mux_data = mlxplat_default_mux_data;
++	for (i = 0; i < mlxplat_mux_num; i++) {
++		mlxplat_mux_data[i].values = mlxplat_msn21xx_channels;
++		mlxplat_mux_data[i].n_values =
++				ARRAY_SIZE(mlxplat_msn21xx_channels);
++	}
++	mlxplat_hotplug = &mlxplat_mlxcpld_dgx_ext_data;
++	mlxplat_hotplug->deferred_nr =
++		mlxplat_msn21xx_channels[MLXPLAT_CPLD_GRP_CHNL_NUM - 1];
++	mlxplat_led = &mlxplat_default_ng_led_data;
++	mlxplat_regs_io = &mlxplat_dgx_ng_regs_io_data;
++	mlxplat_fan = &mlxplat_default_fan_data;
++	for (i = 0; i < ARRAY_SIZE(mlxplat_mlxcpld_wd_set_type2); i++)
++		mlxplat_wd_data[i] = &mlxplat_mlxcpld_wd_set_type2[i];
++	mlxplat_i2c = &mlxplat_mlxcpld_i2c_ng_data;
++	mlxplat_regmap_config = &mlxplat_mlxcpld_regmap_config_ng400;
++
++	return mlxplat_register_platform_device();
++}
++
+ static int __init mlxplat_dmi_modular_matched(const struct dmi_system_id *dmi)
+ {
+ 	int i;
+@@ -8421,6 +8870,13 @@ static const struct dmi_system_id mlxplat_dmi_table[] __initconst = {
+ 		},
+ 	},
+ 	{
++		.callback = mlxplat_dmi_ng400_dgx_matched,
++		.matches = {
++			DMI_MATCH(DMI_BOARD_NAME, "VMOD0010"),
++			DMI_EXACT_MATCH(DMI_PRODUCT_SKU, "HI173"),
++		},
++	},
++	{
+ 		.callback = mlxplat_dmi_ng400_matched,
+ 		.matches = {
+ 			DMI_MATCH(DMI_BOARD_NAME, "VMOD0010"),
+-- 
+2.8.4
+

--- a/patch/0099-platform-mellanox-Downstream-Add-support-DGX-flavor-.patch
+++ b/patch/0099-platform-mellanox-Downstream-Add-support-DGX-flavor-.patch
@@ -1,0 +1,70 @@
+From fc7c0147a6816741ac6a3323b80e0debbbb6dbd4 Mon Sep 17 00:00:00 2001
+From: Oleksandr Shamray <oleksandrs@nvidia.com>
+Date: Mon, 9 Dec 2024 13:38:05 +0200
+Subject: [PATCH 08/15] platform: mellanox: Downstream: Add support DGX flavor
+ of next-generation 800GB/s ethernet switch.
+MIME-Version: 1.0
+Content-Type: text/plain; charset=UTF-8
+Content-Transfer-Encoding: 8bit
+
+This system is based on Nvidia SN5600 Spectrum™-4 Based 64x800Gb/s ETH Switch System, with the
+following key changes:
+
+Key changes:
+- New Power Supply: AC/DC PSUs power repaced by rack busbar input power ORv3 DC 48V-54V.
+- Dimensions MGX/DGX 1U compliance Tool-less top cover (fast cover opening with no scre
+
+Signed-off-by: Oleksandr Shamray <oleksandrs@nvidia.com>
+---
+ drivers/platform/mellanox/mlx-platform.c | 28 ++++++++++++++++++++++++++++
+ 1 file changed, 28 insertions(+)
+
+diff --git a/drivers/platform/mellanox/mlx-platform.c b/drivers/platform/mellanox/mlx-platform.c
+index 9346c76..0c42da1 100644
+--- a/drivers/platform/mellanox/mlx-platform.c
++++ b/drivers/platform/mellanox/mlx-platform.c
+@@ -8677,6 +8677,27 @@ static int __init mlxplat_dmi_ng800_matched(const struct dmi_system_id *dmi)
+ 	return mlxplat_register_platform_device();
+ }
+ 
++static int __init mlxplat_dmi_ng800_dgx_matched(const struct dmi_system_id *dmi)
++{
++    int i;
++
++    mlxplat_max_adap_num = MLXPLAT_CPLD_MAX_PHYS_ADAPTER_NUM;
++    mlxplat_mux_num = ARRAY_SIZE(mlxplat_ng800_mux_data);
++    mlxplat_mux_data = mlxplat_ng800_mux_data;
++    mlxplat_hotplug = &mlxplat_mlxcpld_dgx_ext_data;
++    mlxplat_hotplug->deferred_nr =
++		   mlxplat_msn21xx_channels[MLXPLAT_CPLD_GRP_CHNL_NUM - 1];
++    mlxplat_led = &mlxplat_default_ng_led_data;
++    mlxplat_regs_io = &mlxplat_default_ng_regs_io_data;
++    mlxplat_fan = &mlxplat_default_fan_data;
++    for (i = 0; i < ARRAY_SIZE(mlxplat_mlxcpld_wd_set_type2); i++)
++		   mlxplat_wd_data[i] = &mlxplat_mlxcpld_wd_set_type2[i];
++    mlxplat_i2c = &mlxplat_mlxcpld_i2c_ng_data;
++    mlxplat_regmap_config = &mlxplat_mlxcpld_regmap_config_ng400;
++
++    return mlxplat_register_platform_device();
++}
++
+ static int __init mlxplat_dmi_l1_switch_matched(const struct dmi_system_id *dmi)
+ {
+ 	int i;
+@@ -8889,6 +8910,13 @@ static const struct dmi_system_id mlxplat_dmi_table[] __initconst = {
+ 		},
+ 	},
+ 	{
++	    .callback = mlxplat_dmi_ng800_dgx_matched,
++	    .matches = {
++			DMI_MATCH(DMI_BOARD_NAME, "VMOD0013"),
++			DMI_EXACT_MATCH(DMI_PRODUCT_SKU, "HI174"),
++	    },
++	},
++	{
+ 		.callback = mlxplat_dmi_ng800_matched,
+ 		.matches = {
+ 			DMI_MATCH(DMI_BOARD_NAME, "VMOD0013"),
+-- 
+2.8.4
+

--- a/patch/0100-platform-mellanox-mlxreg-io-Extend-number-of-hwmon-a.patch
+++ b/patch/0100-platform-mellanox-mlxreg-io-Extend-number-of-hwmon-a.patch
@@ -1,0 +1,33 @@
+From 41b6df4fb187cd6a4bbf501017090821825d3bef Mon Sep 17 00:00:00 2001
+From: Oleksandr Shamray <oleksandrs@nvidia.com>
+Date: Wed, 5 Feb 2025 14:45:21 +0200
+Subject: [PATCH] platform/mellanox: mlxreg-io: Extend number of hwmon
+ attributes
+
+Extend maximum number of the attributes, exposed to 'sysfs' to support
+new systems having more attributes.
+
+Signed-off-by: Oleksandr Shamray <oleksandrs@nvidia.com>
+Reviewed-by: Vadim Pasternak <vadimp@nvidia.com>
+
+Signed-off-by: Oleksandr Shamray <oleksandrs@nvidia.com>
+---
+ drivers/platform/mellanox/mlxreg-io.c | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/drivers/platform/mellanox/mlxreg-io.c b/drivers/platform/mellanox/mlxreg-io.c
+index ddc08ab..881182c 100644
+--- a/drivers/platform/mellanox/mlxreg-io.c
++++ b/drivers/platform/mellanox/mlxreg-io.c
+@@ -18,7 +18,7 @@
+ 
+ /* Attribute parameters. */
+ #define MLXREG_IO_ATT_SIZE	10
+-#define MLXREG_IO_ATT_NUM	96
++#define MLXREG_IO_ATT_NUM	128
+ 
+ /**
+  * struct mlxreg_io_priv_data - driver's private data:
+-- 
+2.8.4
+

--- a/patch/0101-platform_data-mlxreg-Add-fields-for-interrupt-storm-.patch
+++ b/patch/0101-platform_data-mlxreg-Add-fields-for-interrupt-storm-.patch
@@ -1,0 +1,63 @@
+From 67a686455cf959f8736b86d42aed06b446efb001 Mon Sep 17 00:00:00 2001
+From: Roy Cohen <roycohen@nvidia.com>
+Date: Mon, 13 Jan 2025 10:47:27 +0200
+Subject: [PATCH platform-next 1/2] platform_data/mlxreg: Add fields for
+ interrupt storm handling
+
+Add fields for interrupt storm handling.
+Extend structure mlxreg_core_data with the following fields:
+ 'wmark_low_cntr' - interrupt storm counter.
+ 'mark_low_ts'    - interrupt storm low bound timestamp.
+ 'wmark_high_ts'  - interrupt storm high bound timestamp.
+
+Extend structure mlxreg_core_item with the following field:
+ 'storming_bits' - interrupt storming bits mask.
+
+Signed-off-by: Roy Cohen <roycohen@nvidia.com>
+---
+ include/linux/platform_data/mlxreg.h | 8 ++++++++
+ 1 file changed, 8 insertions(+)
+
+diff --git a/include/linux/platform_data/mlxreg.h b/include/linux/platform_data/mlxreg.h
+index d9f679752226..67dddacfa8fa 100644
+--- a/include/linux/platform_data/mlxreg.h
++++ b/include/linux/platform_data/mlxreg.h
+@@ -133,6 +133,9 @@ struct mlxreg_hotplug_device {
+  * @regnum: number of registers occupied by multi-register attribute;
+  * @slot: slot number, at which device is located;
+  * @secured: if set indicates that entry access is secured;
++ * @wmark_low_cntr: interrupt storm counter;
++ * @wmark_low_ts: interrupt storm low bound timestamp;
++ * @wmark_high_ts: interrupt storm high bound timestamp;
+  */
+ struct mlxreg_core_data {
+ 	char label[MLXREG_CORE_LABEL_MAX_SIZE];
+@@ -155,6 +158,9 @@ struct mlxreg_core_data {
+ 	u8 regnum;
+ 	u8 slot;
+ 	u8 secured;
++	unsigned int wmark_low_cntr;
++	unsigned long wmark_low_ts;
++	unsigned long wmark_high_ts;
+ };
+ 
+ /**
+@@ -173,6 +179,7 @@ struct mlxreg_core_data {
+  * @ind: element's index inside the group;
+  * @inversed: if 0: 0 for signal status is OK, if 1 - 1 is OK;
+  * @health: true if device has health indication, false in other case;
++ * @storming_bits: interrupt storming bits mask;
+  */
+ struct mlxreg_core_item {
+ 	struct mlxreg_core_data *data;
+@@ -188,6 +195,7 @@ struct mlxreg_core_item {
+ 	u8 ind;
+ 	u8 inversed;
+ 	u8 health;
++	u32 storming_bits;
+ };
+ 
+ /**
+-- 
+2.44.0
+

--- a/patch/0102-platform-mellanox-mlxreg-hotplug-Add-support-for-han.patch
+++ b/patch/0102-platform-mellanox-mlxreg-hotplug-Add-support-for-han.patch
@@ -1,0 +1,116 @@
+From 4a7d1fd44e3394961878761ba0c53f516f31d618 Mon Sep 17 00:00:00 2001
+From: Roy Cohen <roycohen@nvidia.com>
+Date: Mon, 13 Jan 2025 10:50:25 +0200
+Subject: [PATCH platform-next 2/2] platform/mellanox: mlxreg-hotplug: Add
+ support for handling interrupt storm
+
+In case of broken hardware, it is possible that broken device will
+flood interrupt handler with false events.
+For example, if fan or power supply has damaged presence pin, it will
+cause permanent generation of presence in / presence out events.
+As a result, interrupt handler will consume a lot of CPU resources and
+will keep raising "UDEV" events to the user space.
+
+At the same device with damaged pin still will be capable to provide
+telemetry date.
+
+Provide mechanism allowing to detect device causing interrupt flooding
+and mask interrupt for this specific device, to isolate from interrupt
+handling flow.
+
+Use the following criteria: if the specific interrupt was generated 'N'
+time during 'T' seconds, such device is to be considered as broken and
+will be closed for getting interrupts.
+
+User will be notified through the log error and will be instructed to
+replace broken device.
+
+Signed-off-by: Roy Cohen <roycohen@nvidia.com>
+---
+ drivers/platform/mellanox/mlxreg-hotplug.c | 36 ++++++++++++++++++++--
+ 1 file changed, 33 insertions(+), 3 deletions(-)
+
+diff --git a/drivers/platform/mellanox/mlxreg-hotplug.c b/drivers/platform/mellanox/mlxreg-hotplug.c
+index 3737af0d3e43..37d4c02c128a 100644
+--- a/drivers/platform/mellanox/mlxreg-hotplug.c
++++ b/drivers/platform/mellanox/mlxreg-hotplug.c
+@@ -11,6 +11,7 @@
+ #include <linux/hwmon-sysfs.h>
+ #include <linux/i2c.h>
+ #include <linux/interrupt.h>
++#include <linux/jiffies.h>
+ #include <linux/module.h>
+ #include <linux/of_device.h>
+ #include <linux/platform_data/mlxreg.h>
+@@ -31,6 +32,11 @@
+ #define MLXREG_HOTPLUG_ATTRS_MAX	128
+ #define MLXREG_HOTPLUG_NOT_ASSERT	3
+ 
++/* Interrupt storm definitios */
++#define MLXREG_HOTPLUG_WM_COUNTER 100
++/* Time window in milliseconds */
++#define MLXREG_HOTPLUG_WM_WINDOW 3000
++
+ /**
+  * struct mlxreg_hotplug_priv_data - platform private data:
+  * @irq: platform device interrupt number;
+@@ -364,7 +370,7 @@ mlxreg_hotplug_work_helper(struct mlxreg_hotplug_priv_data *priv,
+ 			   struct mlxreg_core_item *item)
+ {
+ 	struct mlxreg_core_data *data;
+-	unsigned long asserted;
++	unsigned long asserted, wmark_low_ts_window;
+ 	u32 regval, bit;
+ 	int ret;
+ 
+@@ -400,11 +406,35 @@ mlxreg_hotplug_work_helper(struct mlxreg_hotplug_priv_data *priv,
+ 	for_each_set_bit(bit, &asserted, 8) {
+ 		int pos;
+ 
++		/* Skip already marked storming bit. */
++		if (item->storming_bits & BIT(bit))
++			continue;
++
+ 		pos = mlxreg_hotplug_item_label_index_get(item->mask, bit);
+ 		if (pos < 0)
+ 			goto out;
+ 
+ 		data = item->data + pos;
++
++		/* Interrupt storm handling logic. */
++		if (data->wmark_low_cntr == 0)
++			data->wmark_low_ts = jiffies;
++
++		data->wmark_low_cntr++;
++		if (data->wmark_low_cntr >= MLXREG_HOTPLUG_WM_COUNTER - 1) {
++			data->wmark_high_ts = jiffies;
++			wmark_low_ts_window = data->wmark_low_ts +
++					      msecs_to_jiffies(MLXREG_HOTPLUG_WM_WINDOW);
++			if (time_after(wmark_low_ts_window, data->wmark_high_ts)) {
++				dev_err(priv->dev, "Storming bit %d (label: %s) - interrupt masked permanently. Replace broken HW.",
++					bit, data->label);
++				/* Mark bit as storming. */
++				item->storming_bits |= BIT(bit);
++			} else {
++				data->wmark_low_cntr = 0;
++			}
++		}
++
+ 		if (regval & BIT(bit)) {
+ 			if (item->inversed)
+ 				mlxreg_hotplug_device_destroy(priv, data, item->kind);
+@@ -424,9 +454,9 @@ mlxreg_hotplug_work_helper(struct mlxreg_hotplug_priv_data *priv,
+ 	if (ret)
+ 		goto out;
+ 
+-	/* Unmask event. */
++	/* Unmask event, exclude storming bits. */
+ 	ret = regmap_write(priv->regmap, item->reg + MLXREG_HOTPLUG_MASK_OFF,
+-			   item->mask);
++			   item->mask & ~item->storming_bits);
+ 
+  out:
+ 	if (ret)
+-- 
+2.44.0
+

--- a/patch/0103-platform-mellanox-mlx-dpu-improve-interrupt-handling.patch
+++ b/patch/0103-platform-mellanox-mlx-dpu-improve-interrupt-handling.patch
@@ -1,0 +1,155 @@
+From edf1951c7f5e87a9b6c2ad82bd97866012f552a6 Mon Sep 17 00:00:00 2001
+From: Ciju Rajan K <crajank@nvidia.com>
+Date: Tue, 25 Mar 2025 11:20:04 +0200
+Subject: [PATCH 01/22] From 4b17e10a22771fcd2dbb4754c43200af2fc69425 Mon Sep
+ 17 00:00:00 2001 From: Ciju Rajan K <crajank@nvidia.com> Date: Tue, 18 Mar
+ 2025 21:15:00 +0200 Subject: platform/mellanox: mlxreg-dpu: Introduce
+ completion callback
+
+DPU auxiliary powering can cause interrupt flooding because
+DPU interrupt handlers are not configured yet, while middle
+interrupt aggregation register is unmasked by default during
+initialization. Thus, interrupts are getting through, while
+handlers are still not fully initialized. Do not unmask
+aggregation interrupt register at initialization for all
+DPUs. Instead do it per DPU, when its initialization is done.
+
+This patch also adds the change to clear the DPU event
+registers.
+
+Signed-off-by: Vadim Pasternak <vadimp@nvidia.com>
+Signed-off-by: Ciju Rajan K <crajank@nvidia.com>
+---
+ drivers/platform/mellanox/mlx-platform.c | 28 +++++++++++++++++++++---
+ drivers/platform/mellanox/mlxreg-dpu.c   |  8 +++++++
+ include/linux/platform_data/mlxreg.h     |  4 ++++
+ 3 files changed, 37 insertions(+), 3 deletions(-)
+
+diff --git a/drivers/platform/mellanox/mlx-platform.c b/drivers/platform/mellanox/mlx-platform.c
+index b1713d805..d2dfdac34 100644
+--- a/drivers/platform/mellanox/mlx-platform.c
++++ b/drivers/platform/mellanox/mlx-platform.c
+@@ -2198,6 +2198,8 @@ static struct mlxreg_core_data mlxplat_mlxcpld_modular_pwr_items_data[] = {
+ 	},
+ };
+ 
++#define MLXPLAT_SMART_SWITCH_SLOT_TO_MASK(s)   (GENMASK((s) * 2 - 1, (s) * 2 - 2))
++
+ 
+ static
+ struct mlxreg_core_hotplug_platform_data mlxplat_mlxcpld_lc_act = {
+@@ -3334,6 +3336,23 @@ static struct mlxreg_core_item mlxplat_mlxcpld_smart_switch_items[] = {
+ 	},
+ };
+ 
++static int mlxplat_dpu_completion_notify(void *handle, int id)
++{
++       u32 regval, mask;
++       int err;
++
++       if (id <= 0 || id > 4)
++               return -EINVAL;
++
++       err = regmap_read(handle, MLXPLAT_CPLD_LPC_REG_AGGRCX_MASK_OFFSET, &regval);
++       if (err)
++               return err;
++
++       mask = MLXPLAT_SMART_SWITCH_SLOT_TO_MASK(id);
++
++       return regmap_write(handle, MLXPLAT_CPLD_LPC_REG_AGGRCX_MASK_OFFSET, regval | mask);
++}
++
+ static
+ struct mlxreg_core_hotplug_platform_data mlxplat_mlxcpld_smart_switch_data = {
+ 	.items = mlxplat_mlxcpld_smart_switch_items,
+@@ -3371,24 +3390,28 @@ static struct mlxreg_core_data mlxplat_mlxcpld_smart_switch_dpu_data[] = {
+ 		.hpdev.brdinfo = &mlxplat_mlxcpld_smart_switch_dpu_devs[0],
+ 		.hpdev.nr = MLXPLAT_CPLD_NR_DPU_BASE,
+ 		.slot = 1,
++		.completion_notify = mlxplat_dpu_completion_notify,
+ 	},
+ 	{
+ 		.label = "dpu2",
+ 		.hpdev.brdinfo = &mlxplat_mlxcpld_smart_switch_dpu_devs[1],
+ 		.hpdev.nr = MLXPLAT_CPLD_NR_DPU_BASE + 1,
+ 		.slot = 2,
++		.completion_notify = mlxplat_dpu_completion_notify,
+ 	},
+ 	{
+ 		.label = "dpu3",
+ 		.hpdev.brdinfo = &mlxplat_mlxcpld_smart_switch_dpu_devs[2],
+ 		.hpdev.nr = MLXPLAT_CPLD_NR_DPU_BASE + 2,
+ 		.slot = 3,
++		.completion_notify = mlxplat_dpu_completion_notify,
+ 	},
+ 	{
+ 		.label = "dpu4",
+-		.hpdev.brdinfo = &mlxplat_mlxcpld_smart_switch_dpu_devs[2],
++		.hpdev.brdinfo = &mlxplat_mlxcpld_smart_switch_dpu_devs[3],
+ 		.hpdev.nr = MLXPLAT_CPLD_NR_DPU_BASE + 3,
+ 		.slot = 4,
++		.completion_notify = mlxplat_dpu_completion_notify,
+ 	},
+ };
+ 
+@@ -8018,8 +8041,6 @@ static const struct reg_default mlxplat_mlxcpld_regmap_smart_switch[] = {
+ 	{ MLXPLAT_CPLD_LPC_REG_WD1_ACT_OFFSET, 0x00 },
+ 	{ MLXPLAT_CPLD_LPC_REG_WD2_ACT_OFFSET, 0x00 },
+ 	{ MLXPLAT_CPLD_LPC_REG_WD3_ACT_OFFSET, 0x00 },
+-	{ MLXPLAT_CPLD_LPC_REG_AGGRCX_MASK_OFFSET,
+-	  MLXPLAT_CPLD_LPC_SM_SW_MASK },
+ };
+ 
+ struct mlxplat_mlxcpld_regmap_context {
+@@ -9333,6 +9354,7 @@ static int mlxplat_post_init(struct mlxplat_priv *priv)
+ 	/* Add DPU drivers. */
+ 	for (j = 0; j < MLXPLAT_CPLD_DPU_MAX_DEVS; j++) {
+ 		if (mlxplat_dpu_data[j]) {
++			mlxplat_dpu_data[j]->handle = priv->regmap;
+ 			priv->pdev_dpu[j] =
+ 				platform_device_register_resndata(&mlxplat_dev->dev, "mlxreg-dpu",
+ 								  j, NULL, 0, mlxplat_dpu_data[j],
+diff --git a/drivers/platform/mellanox/mlxreg-dpu.c b/drivers/platform/mellanox/mlxreg-dpu.c
+index b7685012d..aa8923c49 100644
+--- a/drivers/platform/mellanox/mlxreg-dpu.c
++++ b/drivers/platform/mellanox/mlxreg-dpu.c
+@@ -581,6 +581,14 @@ static int mlxreg_dpu_probe(struct platform_device *pdev)
+ 	if (err)
+ 		goto mlxreg_dpu_config_init_fail;
+ 
++	err = data->completion_notify(data->handle, data->slot);
++	if (err)
++		goto mlxreg_dpu_completion_notify_fail;
++
++	return err;
++
++mlxreg_dpu_completion_notify_fail:
++	mlxreg_dpu_config_exit(mlxreg_dpu);
+ mlxreg_dpu_config_init_fail:
+ regcache_sync_fail:
+ devm_regmap_init_i2c_fail:
+diff --git a/include/linux/platform_data/mlxreg.h b/include/linux/platform_data/mlxreg.h
+index 67dddacfa..e8f2032b3 100644
+--- a/include/linux/platform_data/mlxreg.h
++++ b/include/linux/platform_data/mlxreg.h
+@@ -136,6 +136,8 @@ struct mlxreg_hotplug_device {
+  * @wmark_low_cntr: interrupt storm counter;
+  * @wmark_low_ts: interrupt storm low bound timestamp;
+  * @wmark_high_ts: interrupt storm high bound timestamp;
++ * @handle: parent handle;
++ * @completion_notify: callback to notify when platform driver probing is done;
+  */
+ struct mlxreg_core_data {
+ 	char label[MLXREG_CORE_LABEL_MAX_SIZE];
+@@ -161,6 +163,8 @@ struct mlxreg_core_data {
+ 	unsigned int wmark_low_cntr;
+ 	unsigned long wmark_low_ts;
+ 	unsigned long wmark_high_ts;
++	void *handle;
++	int (*completion_notify)(void *handle, int id);
+ };
+ 
+ /**
+-- 
+2.44.0
+

--- a/patch/8012-hwmon-pmbus-Downstream-Workaround-for-psu-attributes.patch
+++ b/patch/8012-hwmon-pmbus-Downstream-Workaround-for-psu-attributes.patch
@@ -1,0 +1,37 @@
+From b8a552a5eb168b5f53292f639668eec5ece93935 Mon Sep 17 00:00:00 2001
+From: Ciju Rajan K <crajank@nvidia.com>
+Date: Thu, 10 Oct 2024 14:13:28 +0300
+Subject: hwmon: pmbus: Downstream: Workaround for psu attributes
+
+Starting from kernel 5.12.rc-1, pmbus reads are always
+forced down to chip and get the values directly. Driver
+doesn't cache the values anymore.
+
+This behviour change has caused problems in Delta-1.1K
+PSUs, on which pmbus registers were not written.
+
+This patch introduces the driver caching.
+
+Bugs# 3874682
+
+Signed-off-by: Ciju Rajan K <crajank@nvidia.com>
+---
+ drivers/hwmon/pmbus/pmbus_core.c | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/drivers/hwmon/pmbus/pmbus_core.c b/drivers/hwmon/pmbus/pmbus_core.c
+index 7ec049347..464ba9d5a 100644
+--- a/drivers/hwmon/pmbus/pmbus_core.c
++++ b/drivers/hwmon/pmbus/pmbus_core.c
+@@ -1173,7 +1173,7 @@ static ssize_t pmbus_set_sensor(struct device *dev,
+ 	if (ret < 0)
+ 		rv = ret;
+ 	else
+-		sensor->data = -ENODATA;
++		sensor->data = regval;
+ 	mutex_unlock(&data->update_lock);
+ 	return rv;
+ }
+-- 
+2.44.0
+

--- a/patch/series
+++ b/patch/series
@@ -107,6 +107,7 @@ Support-for-fullcone-nat.patch
 0027-platform-mellanox-mlx-platform-Get-interrupt-line-th.patch
 0028-platform-mellanox-Add-initial-support-for-PCIe-based.patch
 0029-platform-mellanox-mlxreg-hotplug-Extend-condition-fo.patch
+0030-1-platform-mellanox-nvsw-sn2201-Add-check-for-platform.patch
 0030-platform-mellanox-nvsw-sn2201-change-fans-i2c-busses.patch
 0032-platform_data-mlxreg-Add-field-with-mapped-resource-.patch
 0033-i2c-mlxcpld-Allow-driver-to-run-on-ARM64-architectur.patch
@@ -143,6 +144,12 @@ Support-for-fullcone-nat.patch
 0094-i2c-asf-Introduce-MCTP-support-over-ASF-controller.patch
 0095-platform-mellanox-nvsw-sn2201-Add-support-for-new-sy.patch
 0097-platform-mellanox-mlx-platform-Add-support-for-new-N.patch
+0098-platform-mellanox-Downstream-Add-support-for-new-Nvi.patch
+0099-platform-mellanox-Downstream-Add-support-DGX-flavor-.patch
+0100-platform-mellanox-mlxreg-io-Extend-number-of-hwmon-a.patch
+0101-platform_data-mlxreg-Add-fields-for-interrupt-storm-.patch
+0102-platform-mellanox-mlxreg-hotplug-Add-support-for-han.patch
+0103-platform-mellanox-mlx-dpu-improve-interrupt-handling.patch
 8000-mlxsw-Use-weak-reverse-dependencies-for-firmware-fla.patch
 8003-mlxsw-i2c-SONIC-ISSU-Prevent-transaction-execution-f.patch
 8004-mlxsw-minimal-Downstream-Ignore-error-reading-SPAD-r.patch
@@ -153,6 +160,7 @@ Support-for-fullcone-nat.patch
 8009-hwmon-mlxsw-Downstream-Allow-fan-speed-setting-granu.patch
 8010-mlxsw-i2c-Downstream-Add-retry-mechanism-for-failed-.patch
 8011-mlxsw-minimal-Downstream-Disable-ethtool-interface.patch
+8012-hwmon-pmbus-Downstream-Workaround-for-psu-attributes.patch
 ###-> mellanox_hw_mgmt-end
 
 # Cisco patches for 5.10 kernel


### PR DESCRIPTION
 ## Patch List
* 0030-1-platform-mellanox-nvsw-sn2201-Add-check-for-platform.patch : https://github.com/torvalds/linux/commit/d56fbfbaf592
* 0098-platform-mellanox-Downstream-Add-support-for-new-Nvi.patch :
* 0099-platform-mellanox-Downstream-Add-support-DGX-flavor-.patch :
* 0100-platform-mellanox-mlxreg-io-Extend-number-of-hwmon-a.patch :
* 0101-platform_data-mlxreg-Add-fields-for-interrupt-storm-.patch :
* 0102-platform-mellanox-mlxreg-hotplug-Add-support-for-han.patch :
* 0103-platform-mellanox-mlx-dpu-improve-interrupt-handling.patch :
* 8012-hwmon-pmbus-Downstream-Workaround-for-psu-attributes.patch :